### PR TITLE
feat: Add GitHub Actions CI workflow (#26)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10']
+
+    services:
+      postgres:
+        image: postgres:13
+        env:
+          POSTGRES_USER: user
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: pubmed
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Poetry
+      run: |
+        pip install poetry
+        poetry config virtualenvs.create false
+
+    - name: Install dependencies
+      run: poetry install
+
+    - name: Run unit tests
+      run: poetry run pytest -m "not integration"
+
+    - name: Run integration tests
+      env:
+        PML_DB_CONNECTION_STRING: postgresql://user:password@localhost:5432/pubmed
+      run: poetry run pytest -m "integration"


### PR DESCRIPTION
This commit adds a new GitHub Actions workflow to automate testing.

The workflow is configured to:
- Trigger on push and pull requests to the main branch.
- Set up Python 3.10 and install dependencies using Poetry.
- Run both unit and integration tests.
- Use a PostgreSQL service container for the integration tests.