### PR TITLE
feat: Add multi-OS and multi-Python CI testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,25 +8,12 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ['3.10']
-
-    services:
-      postgres:
-        image: postgres:13
-        env:
-          POSTGRES_USER: user
-          POSTGRES_PASSWORD: password
-          POSTGRES_DB: pubmed
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v3
@@ -35,6 +22,11 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Setup PostgreSQL
+      uses: bmizerany/setup-postgres@v3
+      with:
+        version: '13.14.0'
 
     - name: Install Poetry
       run: |
@@ -49,5 +41,5 @@ jobs:
 
     - name: Run integration tests
       env:
-        PML_DB_CONNECTION_STRING: postgresql://user:password@localhost:5432/pubmed
+        PML_DB_CONNECTION_STRING: postgresql://postgres:postgres@localhost:5432/postgres
       run: poetry run pytest -m "integration"


### PR DESCRIPTION
This commit enhances the GitHub Actions workflow to support testing across multiple operating systems and Python versions.

The CI matrix now includes:
- OS: ubuntu-latest, macos-latest, windows-latest
- Python: 3.10, 3.11, 3.12

To enable cross-platform integration testing, the PostgreSQL service container has been replaced with the `bmizerany/setup-postgres` action, which works on all supported operating systems.