### PR TITLE
feat(ci): Add support for multiple OS and Python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,36 @@ on:
     branches: [ main, develop ]
 
 jobs:
-  test:
+  unit-tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.10', '3.11', '3.12']
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Poetry
+      run: |
+        pip install poetry
+        poetry config virtualenvs.create false
+
+    - name: Install dependencies
+      run: poetry install
+
+    - name: Run unit tests
+      run: poetry run pytest -m "not integration"
+
+  integration-tests:
     runs-on: ubuntu-latest
+    needs: unit-tests
     strategy:
       matrix:
         python-version: ['3.10']
@@ -43,9 +71,6 @@ jobs:
 
     - name: Install dependencies
       run: poetry install
-
-    - name: Run unit tests
-      run: poetry run pytest -m "not integration"
 
     - name: Run integration tests
       env:


### PR DESCRIPTION
This commit enhances the GitHub Actions workflow to run tests across a matrix of operating systems and Python versions.

The changes include:
- Splitting the test job into `unit-tests` and `integration-tests`.
- Running `unit-tests` on `ubuntu-latest`, `macos-latest`, and `windows-latest`.
- Running `unit-tests` on Python versions `3.10`, `3.11`, and `3.12`.
- Running `integration-tests` only on `ubuntu-latest` with Python `3.10` to accommodate the PostgreSQL service dependency.